### PR TITLE
 Merge Populate v2 to models

### DIFF
--- a/server/djangoapp/admin.py
+++ b/server/djangoapp/admin.py
@@ -8,6 +8,7 @@ admin.site.register(CarModel)
 
 # CarModelInline class
 
+
 # CarModelAdmin class
 class CarModelAdmin(admin.ModelAdmin):
     list_display = ('name', 'car_make', 'type', 'year', 'dealer_id', 'seating_capacity', 'number_of_doors', 'transmission', 'fuel', 'mileage', 'engine_size')
@@ -15,5 +16,8 @@ class CarModelAdmin(admin.ModelAdmin):
     search_fields = ('name', 'car_make_name', 'type', 'transmission', 'fuel')
 
 # CarMakeAdmin class with CarModelInline
+class CarMakeAdmin(admin.ModelAdmin):
+    list_display = ('name', 'description', 'website')
+    search_fields = ('name', 'description')
 
 # Register models here

--- a/server/djangoapp/admin.py
+++ b/server/djangoapp/admin.py
@@ -2,18 +2,15 @@ from django.contrib import admin
 from .models import CarMake, CarModel
 
 
-# Register your models here.
-admin.site.register(CarMake)
-admin.site.register(CarModel)
+# Register your models class here.
 
 # CarModelInline class
-
 
 # CarModelAdmin class
 class CarModelAdmin(admin.ModelAdmin):
     list_display = ('name', 'car_make', 'type', 'year', 'dealer_id', 'seating_capacity', 'number_of_doors', 'transmission', 'fuel', 'mileage', 'engine_size')
     list_filter = ('car_make', 'type', 'year', 'fuel')
-    search_fields = ('name', 'car_make_name', 'type', 'transmission', 'fuel')
+    search_fields = ('name', 'car_make__name', 'type', 'transmission', 'fuel')
 
 # CarMakeAdmin class with CarModelInline
 class CarMakeAdmin(admin.ModelAdmin):
@@ -21,3 +18,5 @@ class CarMakeAdmin(admin.ModelAdmin):
     search_fields = ('name', 'description')
 
 # Register models here
+admin.site.register(CarMake, CarMakeAdmin)
+admin.site.register(CarModel, CarModelAdmin)

--- a/server/djangoapp/admin.py
+++ b/server/djangoapp/admin.py
@@ -9,6 +9,10 @@ admin.site.register(CarModel)
 # CarModelInline class
 
 # CarModelAdmin class
+class CarModelAdmin(admin.ModelAdmin):
+    list_display = ('name', 'car_make', 'type', 'year', 'dealer_id', 'seating_capacity', 'number_of_doors', 'transmission', 'fuel', 'mileage', 'engine_size')
+    list_filter = ('car_make', 'type', 'year', 'fuel')
+    search_fields = ('name', 'car_make_name', 'type', 'transmission', 'fuel')
 
 # CarMakeAdmin class with CarModelInline
 

--- a/server/djangoapp/populate.py
+++ b/server/djangoapp/populate.py
@@ -6,7 +6,7 @@ def initiate():
         {"name":"Mercedes", "description":"Great cars. German technology", "website":"https://www.mercedes-benz.com/"},
         {"name":"Audi", "description":"Great cars. German technology", "website":"https://www.audi.com/"},
         {"name":"Kia", "description":"Great cars. Korean technology", "website":"https://www.kia.com/"},
-        {"name":"Toyota", "description":"Great cars. Japanese technology". "website":"https://www.toyota-global.com/"},
+        {"name":"Toyota", "description":"Great cars. Japanese technology", "website":"https://www.toyota-global.com/"},
     ]
 
     car_make_instances = []

--- a/server/djangoapp/populate.py
+++ b/server/djangoapp/populate.py
@@ -2,16 +2,16 @@ from .models import CarMake, CarModel
 
 def initiate():
     car_make_data = [
-        {"name":"NISSAN", "description":"Great cars. Japanese technology"},
-        {"name":"Mercedes", "description":"Great cars. German technology"},
-        {"name":"Audi", "description":"Great cars. German technology"},
-        {"name":"Kia", "description":"Great cars. Korean technology"},
-        {"name":"Toyota", "description":"Great cars. Japanese technology"},
+        {"name":"NISSAN", "description":"Great cars. Japanese technology", "website":"https://www.nissan-global.com/"},
+        {"name":"Mercedes", "description":"Great cars. German technology", "website":"https://www.mercedes-benz.com/"},
+        {"name":"Audi", "description":"Great cars. German technology", "website":"https://www.audi.com/"},
+        {"name":"Kia", "description":"Great cars. Korean technology", "website":"https://www.kia.com/"},
+        {"name":"Toyota", "description":"Great cars. Japanese technology" "website":"https://www.toyota-global.com/"},
     ]
 
     car_make_instances = []
     for data in car_make_data:
-            car_make_instances.append(CarMake.objects.create(name=data['name'], description=data['description']))
+            car_make_instances.append(CarMake.objects.create(name=data['name'], description=data['description'], website=data['website']))
 
 
     # Create CarModel instances with the corresponding CarMake instances

--- a/server/djangoapp/populate.py
+++ b/server/djangoapp/populate.py
@@ -11,28 +11,38 @@ def initiate():
 
     car_make_instances = []
     for data in car_make_data:
-            car_make_instances.append(CarMake.objects.create(name=data['name'], description=data['description'], website=data['website']))
+        car_make_instances.append(CarMake.objects.create(name=data['name'], description=data['description'], website=data['website']))
 
-
-    # Create CarModel instances with the corresponding CarMake instances
     car_model_data = [
-      {"name":"Pathfinder", "type":"SUV", "year": 2023, "car_make":car_make_instances[0]},
-      {"name":"Qashqai", "type":"SUV", "year": 2023, "car_make":car_make_instances[0]},
-      {"name":"XTRAIL", "type":"SUV", "year": 2023, "car_make":car_make_instances[0]},
-      {"name":"A-Class", "type":"SUV", "year": 2023, "car_make":car_make_instances[1]},
-      {"name":"C-Class", "type":"SUV", "year": 2023, "car_make":car_make_instances[1]},
-      {"name":"E-Class", "type":"SUV", "year": 2023, "car_make":car_make_instances[1]},
-      {"name":"A4", "type":"SUV", "year": 2023, "car_make":car_make_instances[2]},
-      {"name":"A5", "type":"SUV", "year": 2023, "car_make":car_make_instances[2]},
-      {"name":"A6", "type":"SUV", "year": 2023, "car_make":car_make_instances[2]},
-      {"name":"Sorrento", "type":"SUV", "year": 2023, "car_make":car_make_instances[3]},
-      {"name":"Carnival", "type":"SUV", "year": 2023, "car_make":car_make_instances[3]},
-      {"name":"Cerato", "type":"Sedan", "year": 2023, "car_make":car_make_instances[3]},
-      {"name":"Corolla", "type":"Sedan", "year": 2023, "car_make":car_make_instances[4]},
-      {"name":"Camry", "type":"Sedan", "year": 2023, "car_make":car_make_instances[4]},
-      {"name":"Kluger", "type":"SUV", "year": 2023, "car_make":car_make_instances[4]},
+        {"name":"Pathfinder", "type":"SUV", "year": 2023, "car_make":car_make_instances[0], "dealer_id":1, "seating_capacity":7, "number_of_doors":5, "transmission":"automatic", "fuel":"Petrol", "mileage":15000, "engine_size":3500},
+        {"name":"Qashqai", "type":"SUV", "year": 2023, "car_make":car_make_instances[0], "dealer_id":1, "seating_capacity":5, "number_of_doors":5, "transmission":"manual", "fuel":"Diesel", "mileage":20000, "engine_size":1600},
+        {"name":"XTRAIL", "type":"SUV", "year": 2023, "car_make":car_make_instances[0], "dealer_id":1, "seating_capacity":7, "number_of_doors":5, "transmission":"automatic", "fuel":"Hybrid/Petrol", "mileage":10000, "engine_size":2000},
+        {"name":"A-Class", "type":"SUV", "year": 2023, "car_make":car_make_instances[1], "dealer_id":2, "seating_capacity":5, "number_of_doors":5, "transmission":"automatic", "fuel":"Petrol", "mileage":12000, "engine_size":2000},
+        {"name":"C-Class", "type":"SUV", "year": 2023, "car_make":car_make_instances[1], "dealer_id":2, "seating_capacity":5, "number_of_doors":5, "transmission":"manual", "fuel":"Diesel", "mileage":25000, "engine_size":2200},
+        {"name":"E-Class", "type":"SUV", "year": 2023, "car_make":car_make_instances[1], "dealer_id":2, "seating_capacity":5, "number_of_doors":5, "transmission":"automatic", "fuel":"Hybrid/Diesel", "mileage":18000, "engine_size":3000},
+        {"name":"A4", "type":"SUV", "year": 2023, "car_make":car_make_instances[2], "dealer_id":3, "seating_capacity":5, "number_of_doors":5, "transmission":"automatic", "fuel":"Petrol", "mileage":13000, "engine_size":1800},
+        {"name":"A5", "type":"SUV", "year": 2023, "car_make":car_make_instances[2], "dealer_id":3, "seating_capacity":5, "number_of_doors":5, "transmission":"manual", "fuel":"Diesel", "mileage":22000, "engine_size":2000},
+        {"name":"A6", "type":"SUV", "year": 2023, "car_make":car_make_instances[2], "dealer_id":3, "seating_capacity":5, "number_of_doors":5, "transmission":"automatic", "fuel":"Hybrid/Petrol", "mileage":16000, "engine_size":2400},
+        {"name":"Sorrento", "type":"SUV", "year": 2023, "car_make":car_make_instances[3], "dealer_id":4, "seating_capacity":7, "number_of_doors":5, "transmission":"automatic", "fuel":"Petrol", "mileage":14000, "engine_size":3300},
+        {"name":"Carnival", "type":"SUV", "year": 2023, "car_make":car_make_instances[3], "dealer_id":4, "seating_capacity":7, "number_of_doors":5, "transmission":"manual", "fuel":"Diesel", "mileage":23000, "engine_size":2900},
+        {"name":"Cerato", "type":"Sedan", "year": 2023, "car_make":car_make_instances[3], "dealer_id":4, "seating_capacity":5, "number_of_doors":4, "transmission":"automatic", "fuel":"Hybrid/Petrol", "mileage":11000, "engine_size":2000},
+        {"name":"Corolla", "type":"Sedan", "year": 2023, "car_make":car_make_instances[4], "dealer_id":5, "seating_capacity":5, "number_of_doors":4, "transmission":"manual", "fuel":"Petrol", "mileage":13000, "engine_size":1800},
+        {"name":"Camry", "type":"Sedan", "year": 2023, "car_make":car_make_instances[4], "dealer_id":5, "seating_capacity":5, "number_of_doors":4, "transmission":"automatic", "fuel":"Diesel", "mileage":19000, "engine_size":2500},
+        {"name":"Kluger", "type":"SUV", "year": 2023, "car_make":car_make_instances[4], "dealer_id":5, "seating_capacity":7, "number_of_doors":5, "transmission":"automatic", "fuel":"Hybrid/Diesel", "mileage":17000, "engine_size":3200},
         # Add more CarModel instances as needed
     ]
 
     for data in car_model_data:
-            CarModel.objects.create(name=data['name'], car_make=data['car_make'], type=data['type'], year=data['year'])
+        CarModel.objects.create(
+            name=data['name'],
+            car_make=data['car_make'],
+            type=data['type'],
+            year=data['year'],
+            dealer_id=data['dealer_id'],
+            seating_capacity=data['seating_capacity'],
+            number_of_doors=data['number_of_doors'],
+            transmission=data['transmission'],
+            fuel=data['fuel'],
+            mileage=data['mileage'],
+            engine_size=data['engine_size']
+        )

--- a/server/djangoapp/populate.py
+++ b/server/djangoapp/populate.py
@@ -6,7 +6,7 @@ def initiate():
         {"name":"Mercedes", "description":"Great cars. German technology", "website":"https://www.mercedes-benz.com/"},
         {"name":"Audi", "description":"Great cars. German technology", "website":"https://www.audi.com/"},
         {"name":"Kia", "description":"Great cars. Korean technology", "website":"https://www.kia.com/"},
-        {"name":"Toyota", "description":"Great cars. Japanese technology" "website":"https://www.toyota-global.com/"},
+        {"name":"Toyota", "description":"Great cars. Japanese technology". "website":"https://www.toyota-global.com/"},
     ]
 
     car_make_instances = []


### PR DESCRIPTION
This pull request includes significant updates to the `admin.py` and `populate.py` files to enhance the admin interface and data population for the CarMake and CarModel models. The changes improve the manageability and detail of the data within the Django admin interface.

Enhancements to the Django admin interface:

* [`server/djangoapp/admin.py`](diffhunk://#diff-56313ce32287df3ea99aa771823ef678dc18fed58ce0218b746b37482c810760L5-R22): Introduced `CarModelAdmin` and `CarMakeAdmin` classes to customize the display, filtering, and search functionalities for CarModel and CarMake in the admin interface. Additionally, registered these models with their respective admin classes.

Enhancements to data population:

* [`server/djangoapp/populate.py`](diffhunk://#diff-1034e8b4212f8cbb9244721455475f77efd0e3c05c36b6453efa2c09eca3be7aL5-R48): Added a `website` field to the CarMake data and expanded the CarModel data with additional fields such as `dealer_id`, `seating_capacity`, `number_of_doors`, `transmission`, `fuel`, `mileage`, and `engine_size`. This provides a more comprehensive dataset for CarModel instances.