### PR TITLE
 Merge No render to linting

### DIFF
--- a/server/djangoapp/views.py
+++ b/server/djangoapp/views.py
@@ -1,4 +1,3 @@
-from django.shortcuts import render
 from django.http import JsonResponse
 from django.contrib.auth.models import User
 from django.contrib.auth import logout, login, authenticate


### PR DESCRIPTION
This pull request includes a small change to the `server/djangoapp/views.py` file. The change removes the import statement for `render` from `django.shortcuts`, which was not being used in the file.

* [`server/djangoapp/views.py`](diffhunk://#diff-74b908cf8ea547852e3f965a041268a0c4d61c03eae473598f33e06081fd57b6L1): Removed the unused import statement for `render` from `django.shortcuts`.